### PR TITLE
Feat: 워크플로우 핵심 도메인 엔티티 추가

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="Black">
+    <option name="sdkName" value="Python 3.11 (FlowAgent)" />
+  </component>
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="FrameworkDetectionExcludesConfiguration">
     <file type="web" url="file://$PROJECT_DIR$" />

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,25 +5,8 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="33e786c2-31b1-455b-a9d0-8a2a4e7a14b7" name="Changes" comment="">
-      <change beforePath="$PROJECT_DIR$/.gradle/8.14.3/checksums/checksums.lock" beforeDir="false" afterPath="$PROJECT_DIR$/.gradle/8.14.3/checksums/checksums.lock" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/.gradle/8.14.3/executionHistory/executionHistory.bin" beforeDir="false" afterPath="$PROJECT_DIR$/.gradle/8.14.3/executionHistory/executionHistory.bin" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/.gradle/8.14.3/executionHistory/executionHistory.lock" beforeDir="false" afterPath="$PROJECT_DIR$/.gradle/8.14.3/executionHistory/executionHistory.lock" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/.gradle/8.14.3/fileHashes/fileHashes.bin" beforeDir="false" afterPath="$PROJECT_DIR$/.gradle/8.14.3/fileHashes/fileHashes.bin" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/.gradle/8.14.3/fileHashes/fileHashes.lock" beforeDir="false" afterPath="$PROJECT_DIR$/.gradle/8.14.3/fileHashes/fileHashes.lock" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/.gradle/8.14.3/fileHashes/resourceHashesCache.bin" beforeDir="false" afterPath="$PROJECT_DIR$/.gradle/8.14.3/fileHashes/resourceHashesCache.bin" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/.gradle/buildOutputCleanup/buildOutputCleanup.lock" beforeDir="false" afterPath="$PROJECT_DIR$/.gradle/buildOutputCleanup/buildOutputCleanup.lock" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/.gradle/file-system.probe" beforeDir="false" afterPath="$PROJECT_DIR$/.gradle/file-system.probe" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/.idea/compiler.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/compiler.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/.idea/gradle.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/gradle.xml" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/misc.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/misc.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/.idea/modules.xml" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/.idea/modules/SpringBoot.main.iml" beforeDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/SpringBoot/src/main/resources/application.properties" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/SpringBoot/src/main/resources/application.yaml" beforeDir="false" afterPath="$PROJECT_DIR$/SpringBoot/src/main/resources/application.yaml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/SpringBoot/src/main/resources/db.settings" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/SpringBoot/src/test/java/com/auto/kr/springboot/ApplicationTests.java" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/settings.gradle" beforeDir="false" afterPath="$PROJECT_DIR$/settings.gradle" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -69,6 +52,13 @@
       </state>
     </system>
   </component>
+  <component name="FileTemplateManagerImpl">
+    <option name="RECENT_TEMPLATES">
+      <list>
+        <option value="Class" />
+      </list>
+    </option>
+  </component>
   <component name="Git.Settings">
     <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$" />
   </component>
@@ -95,29 +85,29 @@
   <component name="ProjectViewState">
     <option name="showLibraryContents" value="true" />
   </component>
-  <component name="PropertiesComponent">{
-  &quot;keyToString&quot;: {
-    &quot;Gradle.Build FlowAgent.executor&quot;: &quot;Run&quot;,
-    &quot;Gradle.FlowAgent [build].executor&quot;: &quot;Run&quot;,
-    &quot;Gradle.FlowAgent [clean].executor&quot;: &quot;Run&quot;,
-    &quot;Python.test.executor&quot;: &quot;Run&quot;,
-    &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
-    &quot;RunOnceActivity.git.unshallow&quot;: &quot;true&quot;,
-    &quot;Spring Boot.FlowAgentApplication.executor&quot;: &quot;Run&quot;,
-    &quot;git-widget-placeholder&quot;: &quot;develop&quot;,
-    &quot;kotlin-language-version-configured&quot;: &quot;true&quot;,
-    &quot;node.js.detected.package.eslint&quot;: &quot;true&quot;,
-    &quot;node.js.detected.package.tslint&quot;: &quot;true&quot;,
-    &quot;node.js.selected.package.eslint&quot;: &quot;(autodetect)&quot;,
-    &quot;node.js.selected.package.tslint&quot;: &quot;(autodetect)&quot;,
-    &quot;nodejs_package_manager_path&quot;: &quot;npm&quot;,
-    &quot;project.structure.last.edited&quot;: &quot;Modules&quot;,
-    &quot;project.structure.proportion&quot;: &quot;0.15&quot;,
-    &quot;project.structure.side.proportion&quot;: &quot;0.2&quot;,
-    &quot;settings.editor.selected.configurable&quot;: &quot;reference.settingsdialog.project.gradle&quot;,
-    &quot;vue.rearranger.settings.migration&quot;: &quot;true&quot;
+  <component name="PropertiesComponent"><![CDATA[{
+  "keyToString": {
+    "Gradle.Build FlowAgent.executor": "Run",
+    "Gradle.FlowAgent [build].executor": "Run",
+    "Gradle.FlowAgent [clean].executor": "Run",
+    "Python.test.executor": "Run",
+    "RunOnceActivity.ShowReadmeOnStart": "true",
+    "RunOnceActivity.git.unshallow": "true",
+    "Spring Boot.FlowAgentApplication.executor": "Run",
+    "git-widget-placeholder": "feature/create-entities",
+    "kotlin-language-version-configured": "true",
+    "node.js.detected.package.eslint": "true",
+    "node.js.detected.package.tslint": "true",
+    "node.js.selected.package.eslint": "(autodetect)",
+    "node.js.selected.package.tslint": "(autodetect)",
+    "nodejs_package_manager_path": "npm",
+    "project.structure.last.edited": "Modules",
+    "project.structure.proportion": "0.15",
+    "project.structure.side.proportion": "0.2",
+    "settings.editor.selected.configurable": "reference.settingsdialog.project.gradle",
+    "vue.rearranger.settings.migration": "true"
   }
-}</component>
+}]]></component>
   <component name="RunManager" selected="Spring Boot.FlowAgentApplication">
     <configuration name="FlowAgent [build]" type="GradleRunConfiguration" factoryName="Gradle" temporary="true">
       <ExternalSystemSettings>
@@ -197,7 +187,7 @@
       <workItem from="1755074952287" duration="254000" />
       <workItem from="1755075227106" duration="1366000" />
       <workItem from="1755076626482" duration="299000" />
-      <workItem from="1755164281766" duration="1381000" />
+      <workItem from="1755164281766" duration="10706000" />
     </task>
     <servers />
   </component>

--- a/SpringBoot/src/main/java/com/post/kr/flowagent/Connection.java
+++ b/SpringBoot/src/main/java/com/post/kr/flowagent/Connection.java
@@ -1,0 +1,25 @@
+package com.post.kr.flowagent;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "connections")
+public class Connection {
+
+    @Id
+    @Column(name = "connection_id") // 'con_1' 같은 문자열이므로 GeneratedValue 사용 안 함
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "tenant_id", nullable = false)
+    private Tenant tenant;
+
+    @Column(name = "service_name", length = 255)
+    private String serviceName;
+
+    @Column(name = "encrypted_credentials", length = 255)
+    private String encryptedCredentials;
+
+    @Column(name = "is_active", length = 1)
+    private Boolean isActive;
+}

--- a/SpringBoot/src/main/java/com/post/kr/flowagent/StepRun.java
+++ b/SpringBoot/src/main/java/com/post/kr/flowagent/StepRun.java
@@ -1,0 +1,31 @@
+package com.post.kr.flowagent;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "step_runs")
+public class StepRun {
+
+    @Id
+    @Column(name = "step_run_id") // 'srn_001' 같은 문자열이므로 GeneratedValue 사용 안 함
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "workflow_run_id", nullable = false)
+    private WorkflowRun workflowRun;
+
+    @Column(name = "step_name", length = 255)
+    private String stepName;
+
+    @Column(name = "step_status", length = 255)
+    private String stepStatus;
+
+    @Column(name = "step_inputs", columnDefinition = "json")
+    private String inputs;
+
+    @Column(name = "step_outputs", columnDefinition = "json")
+    private String outputs;
+
+    @Column(name = "duration_ms")
+    private Integer durationMs;
+}

--- a/SpringBoot/src/main/java/com/post/kr/flowagent/Tenant.java
+++ b/SpringBoot/src/main/java/com/post/kr/flowagent/Tenant.java
@@ -1,0 +1,40 @@
+package com.post.kr.flowagent;
+import jakarta.persistence.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "tenants")
+public class Tenant {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "tenant_id")
+    private Long id;
+
+    @Column(name = "tenant_name", nullable = false, length = 255)
+    private String tenantName;
+
+    @Column(name = "tenant_status", length = 1)
+    private String tenantStatus;
+
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "update_at")
+    private LocalDateTime updatedAt;
+
+    @OneToMany(mappedBy = "tenant", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<User> users = new ArrayList<>();
+
+    @OneToMany(mappedBy = "tenant", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Workflow> workflows = new ArrayList<>();
+
+    @OneToMany(mappedBy = "tenant", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Connection> connections = new ArrayList<>();
+}

--- a/SpringBoot/src/main/java/com/post/kr/flowagent/User.java
+++ b/SpringBoot/src/main/java/com/post/kr/flowagent/User.java
@@ -1,0 +1,39 @@
+package com.post.kr.flowagent;
+import jakarta.persistence.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "users")
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "tenant_id", nullable = false)
+    private Tenant tenant;
+
+    @Column(name = "first_name", length = 255)
+    private String firstName;
+
+    @Column(name = "last_name", length = 255)
+    private String lastName;
+
+    @Column(name = "email_addr", nullable = false, unique = true, length = 255)
+    private String emailAddr;
+
+    @Column(name = "account_status", length = 255)
+    private String accountStatus;
+
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "update_at")
+    private LocalDateTime updatedAt;
+}

--- a/SpringBoot/src/main/java/com/post/kr/flowagent/Workflow.java
+++ b/SpringBoot/src/main/java/com/post/kr/flowagent/Workflow.java
@@ -1,0 +1,39 @@
+package com.post.kr.flowagent;
+
+import jakarta.persistence.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "workflows")
+public class Workflow {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "workflow_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "tenant_id", nullable = false)
+    private Tenant tenant;
+
+    @Column(name = "workflow_name", length = 255)
+    private String workflowName;
+
+    @Column(name = "is_active", length = 1)
+    private Boolean isActive;
+
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "update_at")
+    private LocalDateTime updatedAt;
+
+    @OneToMany(mappedBy = "workflow", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<WorkflowVersion> versions = new ArrayList<>();
+}

--- a/SpringBoot/src/main/java/com/post/kr/flowagent/WorkflowRun.java
+++ b/SpringBoot/src/main/java/com/post/kr/flowagent/WorkflowRun.java
@@ -1,0 +1,38 @@
+package com.post.kr.flowagent;
+
+import jakarta.persistence.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "workflow_runs")
+public class WorkflowRun {
+
+    @Id
+    @Column(name = "workflow_runs_id") // 'run_id' 등 단순한 이름으로 변경하는 것을 추천
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "workflow_version_id", nullable = false)
+    private WorkflowVersion workflowVersion;
+
+    // Tenant 정보는 workflowVersion을 통해 접근 가능하므로 중복 매핑을 피하거나,
+    // 조인 성능 최적화를 위해 읽기 전용으로 매핑할 수 있습니다.
+    @Column(name = "tenant_id", insertable = false, updatable = false)
+    private Long tenantId;
+
+    @Column(name = "workflow_runs_status", length = 255)
+    private String status;
+
+    @Column(name = "started_at")
+    private LocalDateTime startedAt;
+
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "update_at")
+    private LocalDateTime updatedAt;
+}

--- a/SpringBoot/src/main/java/com/post/kr/flowagent/WorkflowVersion.java
+++ b/SpringBoot/src/main/java/com/post/kr/flowagent/WorkflowVersion.java
@@ -1,0 +1,40 @@
+package com.post.kr.flowagent;
+
+import jakarta.persistence.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+import java.time.LocalDateTime;
+
+/**
+ * 워크 플로우의 실제 로직을 담은 버전
+ */
+@Entity
+@Table(name = "workflow_versions")
+public class WorkflowVersion {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "workflow_version_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "workflow_id", nullable = false)
+    private Workflow workflow;
+
+    @Column(name = "version_number", length = 255)
+    private Integer versionNumber;
+
+    @Column(name = "dag_definition", columnDefinition = "json")
+    private String dagDefinition;
+
+    @Column(name = "is_published", length = 1)
+    private Boolean isPublished;
+
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "update_at")
+    private LocalDateTime updatedAt;
+}


### PR DESCRIPTION
### 개요 (Summary)
워크플로우 자동화 서비스의 기반이 되는 핵심 도메인 엔티티를 추가합니다. 이 PR은 전체 데이터 모델의 뼈대를 설정하며, 각 엔티티 간의 관계를 정의합니다.

주요 변경 사항 (Key Changes)

- **Tenant 엔티티 추가**: 조직(테넌트) 정보 관리

- **User 엔티티 추가**: 사용자 정보 및 소속 Tenant와의 관계 정의 (ManyToOne)

- **Workflow 엔티티 추가**: 사용자가 생성하는 워크플로우의 메타 정보 관리

- **WorkflowVersion 엔티티 추가**: 워크플로우의 실제 로직(DAG) 및 버전 관리

- **Connection 엔티티 추가:** 외부 서비스 연동을 위한 인증 정보 관리

- **WorkflowRun 엔티티 추가**: 워크플로우 실행의 전체 결과 로그

- **StepRun 엔티티 추가**: 워크플로우 각 단계의 상세 결과 로그