### PR TITLE
Feat: 자동 실행을 위한 Trigger 엔티티 추가

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,7 +5,6 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="33e786c2-31b1-455b-a9d0-8a2a4e7a14b7" name="Changes" comment="">
-      <change beforePath="$PROJECT_DIR$/.idea/misc.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/misc.xml" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
@@ -56,6 +55,7 @@
     <option name="RECENT_TEMPLATES">
       <list>
         <option value="Class" />
+        <option value="Enum" />
       </list>
     </option>
   </component>
@@ -85,29 +85,33 @@
   <component name="ProjectViewState">
     <option name="showLibraryContents" value="true" />
   </component>
-  <component name="PropertiesComponent"><![CDATA[{
-  "keyToString": {
-    "Gradle.Build FlowAgent.executor": "Run",
-    "Gradle.FlowAgent [build].executor": "Run",
-    "Gradle.FlowAgent [clean].executor": "Run",
-    "Python.test.executor": "Run",
-    "RunOnceActivity.ShowReadmeOnStart": "true",
-    "RunOnceActivity.git.unshallow": "true",
-    "Spring Boot.FlowAgentApplication.executor": "Run",
-    "git-widget-placeholder": "feature/create-entities",
-    "kotlin-language-version-configured": "true",
-    "node.js.detected.package.eslint": "true",
-    "node.js.detected.package.tslint": "true",
-    "node.js.selected.package.eslint": "(autodetect)",
-    "node.js.selected.package.tslint": "(autodetect)",
-    "nodejs_package_manager_path": "npm",
-    "project.structure.last.edited": "Modules",
-    "project.structure.proportion": "0.15",
-    "project.structure.side.proportion": "0.2",
-    "settings.editor.selected.configurable": "reference.settingsdialog.project.gradle",
-    "vue.rearranger.settings.migration": "true"
+  <component name="PropertiesComponent">{
+  &quot;keyToString&quot;: {
+    &quot;Gradle.Build FlowAgent.executor&quot;: &quot;Run&quot;,
+    &quot;Gradle.FlowAgent [build].executor&quot;: &quot;Run&quot;,
+    &quot;Gradle.FlowAgent [clean].executor&quot;: &quot;Run&quot;,
+    &quot;Python.test.executor&quot;: &quot;Run&quot;,
+    &quot;RequestMappingsPanelOrder0&quot;: &quot;0&quot;,
+    &quot;RequestMappingsPanelOrder1&quot;: &quot;1&quot;,
+    &quot;RequestMappingsPanelWidth0&quot;: &quot;75&quot;,
+    &quot;RequestMappingsPanelWidth1&quot;: &quot;75&quot;,
+    &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.git.unshallow&quot;: &quot;true&quot;,
+    &quot;Spring Boot.FlowAgentApplication.executor&quot;: &quot;Run&quot;,
+    &quot;git-widget-placeholder&quot;: &quot;feature/create-entities&quot;,
+    &quot;kotlin-language-version-configured&quot;: &quot;true&quot;,
+    &quot;node.js.detected.package.eslint&quot;: &quot;true&quot;,
+    &quot;node.js.detected.package.tslint&quot;: &quot;true&quot;,
+    &quot;node.js.selected.package.eslint&quot;: &quot;(autodetect)&quot;,
+    &quot;node.js.selected.package.tslint&quot;: &quot;(autodetect)&quot;,
+    &quot;nodejs_package_manager_path&quot;: &quot;npm&quot;,
+    &quot;project.structure.last.edited&quot;: &quot;Modules&quot;,
+    &quot;project.structure.proportion&quot;: &quot;0.15&quot;,
+    &quot;project.structure.side.proportion&quot;: &quot;0.2&quot;,
+    &quot;settings.editor.selected.configurable&quot;: &quot;reference.settingsdialog.project.gradle&quot;,
+    &quot;vue.rearranger.settings.migration&quot;: &quot;true&quot;
   }
-}]]></component>
+}</component>
   <component name="RunManager" selected="Spring Boot.FlowAgentApplication">
     <configuration name="FlowAgent [build]" type="GradleRunConfiguration" factoryName="Gradle" temporary="true">
       <ExternalSystemSettings>
@@ -187,7 +191,8 @@
       <workItem from="1755074952287" duration="254000" />
       <workItem from="1755075227106" duration="1366000" />
       <workItem from="1755076626482" duration="299000" />
-      <workItem from="1755164281766" duration="10706000" />
+      <workItem from="1755164281766" duration="13302000" />
+      <workItem from="1755272791632" duration="5201000" />
     </task>
     <servers />
   </component>

--- a/SpringBoot/src/main/java/com/post/kr/flowagent/Trigger.java
+++ b/SpringBoot/src/main/java/com/post/kr/flowagent/Trigger.java
@@ -1,0 +1,50 @@
+package com.post.kr.flowagent;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "triggers")
+@Getter
+@Setter
+@NoArgsConstructor
+public class Trigger {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "trigger_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "workflow_version_id", nullable = false)
+    private WorkflowVersion workflowVersion;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "tenant_id", nullable = false)
+    private Tenant tenant;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "trigger_type", nullable = false, length = 50)
+    private TriggerType triggerType;
+
+    @Column(name = "trigger_config", columnDefinition = "json")
+    private String triggerConfig;
+
+    @Column(name = "is_active", nullable = false, length = 1)
+    @ColumnDefault("'T'")
+    private boolean isActive = true;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "update_at", nullable = false)
+    private LocalDateTime updatedAt;
+}

--- a/SpringBoot/src/main/java/com/post/kr/flowagent/TriggerType.java
+++ b/SpringBoot/src/main/java/com/post/kr/flowagent/TriggerType.java
@@ -1,0 +1,6 @@
+package com.post.kr.flowagent;
+
+public enum TriggerType {
+    SCHEDULED,
+    WEBHOOK
+}


### PR DESCRIPTION
### 개요 (Summary)
기존에 정의된 워크플로우를 자동으로 실행시킬 수 있는 Trigger 엔티티를 추가합니다. 이를 통해 스케줄링 또는 웹훅 기반의 워크플로우 자동화가 가능해집니다.

### 주요 변경 사항 (Key Changes)

1. Trigger 엔티티 추가

- 발행된 WorkflowVersion을 실행시키는 조건(스케줄, 웹훅 등)을 정의합니다.
- WorkflowVersion 및 Tenant와 ManyToOne 관계를 맺습니다.
- trigger_config 필드를 JSON 타입으로 정의하여 유연한 설정이 가능하도록 설계했습니다.

2. TriggerType Enum 추가

- 트리거의 종류(SCHEDULED, WEBHOOK)를 타입-세이프하게 관리하기 위해 Enum 클래스를 추가했습니다.

### (To Myself)
trigger_type을 Enum으로 관리하는 방식과 trigger_config를 JSON으로 설계한 부분에 대한 의견 확인해보기